### PR TITLE
Padding of comment text

### DIFF
--- a/_build/assets/scss/components/_community.scss
+++ b/_build/assets/scss/components/_community.scss
@@ -143,7 +143,7 @@
       }
     }
     .comment-text {
-      padding: 10px 5px;
+      padding: 10px 15px;
       border: 1px solid #efefef;
       border-radius: 5px;
       box-shadow: #efefef 0 0 10px;


### PR DESCRIPTION
На мой взгляд так комментарии будут выглядеть немного опрятнее

До:
[![1xahmh](https://user-images.githubusercontent.com/3328625/38850902-e885bce0-422c-11e8-9e89-f4a5a9cf2129.png)](https://user-images.githubusercontent.com/3328625/38850924-ffa47cd6-422c-11e8-916d-76a08569f84a.png)

После:
[![1xahmd](https://user-images.githubusercontent.com/3328625/38850957-1dab39a4-422d-11e8-8446-b78018277d66.png)](https://user-images.githubusercontent.com/3328625/38850968-28299ee8-422d-11e8-8f98-ae7b71294881.png)
